### PR TITLE
Clear optical origin position, debug

### DIFF
--- a/user/mc/pandax/PandaXOpticalDataManager.cc
+++ b/user/mc/pandax/PandaXOpticalDataManager.cc
@@ -142,9 +142,9 @@ void PandaXOpticalDataManager::resetData() {
     tLocal.clear();
     tProper.clear();
     pmtNumber.clear();
-    x.clear();
-    y.clear();
-    z.clear();
+    ox.clear();
+    oy.clear();
+    oz.clear();
     parent.clear();
     photonParentId.clear();
     velocity.clear();


### PR DESCRIPTION
Bug fix. In `PandaXOpticalDataManager`, we have to clear the `ox`, `oy`, and `oz` vectors after the simulation of each event. 